### PR TITLE
Use attribute based scoping instead of classes; small optimizaitons

### DIFF
--- a/example.html
+++ b/example.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>🌘 CSS Scope Inline Test Page</title>
-		<!-- ... or add as inline <script> ! -->
-		<script src="https://cdn.jsdelivr.net/gh/gnat/css-scope-inline/script.js"></script>
+		<script src="script.js"></script>
+		<!-- or srouce from cdn: <script src="https://cdn.jsdelivr.net/gh/gnat/css-scope-inline/script.js"></script> -->
 		<meta http-equiv="cache-control" content="no-cache">
 		<style>
 			*,*::before,*::after { margin: 0; box-sizing: border-box; } /* Reset */

--- a/script.js
+++ b/script.js
@@ -1,14 +1,13 @@
 // 🌘 CSS Scope Inline (https://github.com/gnat/css-scope-inline)
 window.cssScopeCount ??= 1 // Let other scripts read the scope count.
 window.cssScope ??= new MutationObserver(mutations => { // Allow 1 observer.
-	document?.body?.querySelectorAll('style:not([scoped-to])').forEach(node => { // Faster than walking MutationObserver results when recieving subtree (DOM swap, htmx, ajax, jquery).
-		node.parentNode.dataset.cssScope ??= (window.cssScopeCount++)
+	document?.body?.querySelectorAll('style:not([data-css-scope])').forEach(node => { // Faster than walking MutationObserver results when recieving subtree (DOM swap, htmx, ajax, jquery).
+		node.dataset.cssScope = node.parentNode.dataset.cssScope ??= (window.cssScopeCount++)
 		node.textContent = node.textContent
 		.replace(/((@keyframes\s|animation:|animation-name:)[^{};]*)\bme(?![A-Za-z])/g, `$1css-scope-${node.parentNode.dataset.cssScope}`)
 		.replace(/(^|[^-\w])me(?![-\w])/g, `$1[data-css-scope='${node.parentNode.dataset.cssScope}']`)
 		.replace(/(?:@media)\s+(xs-|sm-|md-|lg-|xl-|sm|md|lg|xl|xx)(?![-\w])/g, // Optional responsive design shorthand for @media breakpoints. Mobile First (above breakpoint): 🟢 None sm md lg xl xx 🏁  Desktop First (below breakpoint): 🏁 xs- sm- md- lg- xl- None 🟢
 			(match, part1) => { return '@media '+({'sm':'(min-width: 640px)','md':'(min-width: 768px)', 'lg':'(min-width: 1024px)', 'xl':'(min-width: 1280px)', 'xx':'(min-width: 1536px)', 'xs-':'(max-width: 639px)', 'sm-':'(max-width: 767px)', 'md-':'(max-width: 1023px)', 'lg-':'(max-width: 1279px)', 'xl-':'(max-width: 1535px)'}[part1]) }
 		)
-		node.setAttribute('scoped-to', node.parentNode.dataset.cssScope)
 	})
 }).observe(document.documentElement, {childList: true, subtree: true})

--- a/script.js
+++ b/script.js
@@ -1,8 +1,8 @@
 // 🌘 CSS Scope Inline (https://github.com/gnat/css-scope-inline)
 window.cssScopeCount ??= 1 // Let other scripts read the scope count.
 window.cssScope ??= new MutationObserver(mutations => { // Allow 1 observer.
-	document?.body?.querySelectorAll('style:not([data-css-scope])').forEach(node => { // Faster than walking MutationObserver results when recieving subtree (DOM swap, htmx, ajax, jquery).
-		node.dataset.cssScope = node.parentNode.dataset.cssScope ??= (window.cssScopeCount++)
+	document?.body?.querySelectorAll('style:not([data-css-scoped])').forEach(node => { // Faster than walking MutationObserver results when recieving subtree (DOM swap, htmx, ajax, jquery).
+		node.dataset.cssScoped = node.parentNode.dataset.cssScope ??= (window.cssScopeCount++)
 		node.textContent = node.textContent
 		.replace(/((@keyframes\s|animation:|animation-name:)[^{};]*)\bme(?![A-Za-z])/g, `$1css-scope-${node.parentNode.dataset.cssScope}`)
 		.replace(/(^|[^-\w])me(?![-\w])/g, `$1[data-css-scope='${node.parentNode.dataset.cssScope}']`)

--- a/script.js
+++ b/script.js
@@ -4,8 +4,8 @@ window.cssScope ??= new MutationObserver(mutations => { // Allow 1 observer.
 	document?.body?.querySelectorAll('style:not([scoped-to])').forEach(node => { // Faster than walking MutationObserver results when recieving subtree (DOM swap, htmx, ajax, jquery).
 		node.parentNode.dataset.cssScope ??= (window.cssScopeCount++)
 		node.textContent = node.textContent
-		.replace(/(^|[^-\w])me(?![-\w])/g, `$1[data-css-scope='${node.parentNode.dataset.cssScope}']`)
 		.replace(/((@keyframes\s|animation:|animation-name:)[^{};]*)\bme(?![A-Za-z])/g, `$1css-scope-${node.parentNode.dataset.cssScope}`)
+		.replace(/(^|[^-\w])me(?![-\w])/g, `$1[data-css-scope='${node.parentNode.dataset.cssScope}']`)
 		.replace(/(?:@media)\s+(xs-|sm-|md-|lg-|xl-|sm|md|lg|xl|xx)(?![-\w])/g, // Optional responsive design shorthand for @media breakpoints. Mobile First (above breakpoint): 🟢 None sm md lg xl xx 🏁  Desktop First (below breakpoint): 🏁 xs- sm- md- lg- xl- None 🟢
 			(match, part1) => { return '@media '+({'sm':'(min-width: 640px)','md':'(min-width: 768px)', 'lg':'(min-width: 1024px)', 'xl':'(min-width: 1280px)', 'xx':'(min-width: 1536px)', 'xs-':'(max-width: 639px)', 'sm-':'(max-width: 767px)', 'md-':'(max-width: 1023px)', 'lg-':'(max-width: 1279px)', 'xl-':'(max-width: 1535px)'}[part1]) }
 		)

--- a/script.js
+++ b/script.js
@@ -1,15 +1,14 @@
 // 🌘 CSS Scope Inline (https://github.com/gnat/css-scope-inline)
-window.cssScopeCount ??= 1 // Let extra copies share the scope count.
+window.cssScopeCount ??= 1 // Let other scripts read the scope count.
 window.cssScope ??= new MutationObserver(mutations => { // Allow 1 observer.
-	document?.body?.querySelectorAll('style:not([ready])').forEach(node => { // Faster than walking MutationObserver results when recieving subtree (DOM swap, htmx, ajax, jquery).
-		var scope = 'me__'+(window.cssScopeCount++) // Ready. Make unique scope, example: .me__1234
-		node.parentNode.classList.add(scope)
+	document?.body?.querySelectorAll('style:not([scoped-to])').forEach(node => { // Faster than walking MutationObserver results when recieving subtree (DOM swap, htmx, ajax, jquery).
+		node.parentNode.dataset.cssScope ??= (window.cssScopeCount++)
 		node.textContent = node.textContent
-		.replace(/(?:^|\.|(\s|[^a-zA-Z0-9\-\_]))(me|this|self)(?![a-zA-Z])/g, '$1.'+scope) // Can use: me this self
-		.replace(/((@keyframes|animation:|animation-name:)[^{};]*)\.me__/g, '$1me__') // Optional. Removes need to escape names using \
-		.replace(/(?:@media)\s(xs-|sm-|md-|lg-|xl-|sm|md|lg|xl|xx)/g, // Optional. Responsive design. Mobile First (above breakpoint): 🟢 None sm md lg xl xx 🏁  Desktop First (below breakpoint): 🏁 xs- sm- md- lg- xl- None 🟢 *- matches must be first!
+		.replace(/(^|[^-\w])me(?![-\w])/g, `$1[data-css-scope='${node.parentNode.dataset.cssScope}']`)
+		.replace(/((@keyframes\s|animation:|animation-name:)[^{};]*)\bme(?![A-Za-z])/g, `$1css-scope-${node.parentNode.dataset.cssScope}`)
+		.replace(/(?:@media)\s+(xs-|sm-|md-|lg-|xl-|sm|md|lg|xl|xx)(?![-\w])/g, // Optional responsive design shorthand for @media breakpoints. Mobile First (above breakpoint): 🟢 None sm md lg xl xx 🏁  Desktop First (below breakpoint): 🏁 xs- sm- md- lg- xl- None 🟢
 			(match, part1) => { return '@media '+({'sm':'(min-width: 640px)','md':'(min-width: 768px)', 'lg':'(min-width: 1024px)', 'xl':'(min-width: 1280px)', 'xx':'(min-width: 1536px)', 'xs-':'(max-width: 639px)', 'sm-':'(max-width: 767px)', 'md-':'(max-width: 1023px)', 'lg-':'(max-width: 1279px)', 'xl-':'(max-width: 1535px)'}[part1]) }
 		)
-		node.setAttribute('ready', '')
+		node.setAttribute('scoped-to', node.parentNode.dataset.cssScope)
 	})
 }).observe(document.documentElement, {childList: true, subtree: true})


### PR DESCRIPTION
* Only support using `me`. The 'extra flexibility' is unnecessary and distracting. If users want a different selector then they can edit it, it's only 12 lines of code.
* Use data attributes to identify the parent scope id and select it; this is less likely to interact with existing css tooling and classes, and makes it easier to identify by eye.
* Combine parent and child scope id assignment and currentScopeId increment, reducing the size of the script by 2 lines.
* Only creates a parent's scope id once, multiple scoped style children will share the same id.
* Adjust the regexes to be more selective about what to replace